### PR TITLE
Append current dir to PYTHONPATH

### DIFF
--- a/Parametric_Curve_FP.FCMacro
+++ b/Parametric_Curve_FP.FCMacro
@@ -2070,7 +2070,9 @@ ParametricCurve feature python objects.  May we proceed?\n\n"
             noImport = True
 
     if not noImport: #don't never use no double negatives
-
+        import sys
+        import os
+        sys.path.append(os.path.dirname(os.path.abspath(__file__)))
         import Parametric_Curve_FP
         if Parametric_Curve_FP.__version__ != __version__:
             writeFile()


### PR DESCRIPTION
I encountered the error in FreeCAD (realthunder) that this macro cannot
find Parametric_Curve_FP module because the path is not there.

This PR added current dir to PYTHONPATH explicitly to resolve this
issue.